### PR TITLE
Add Team2 vCluster infrastructure

### DIFF
--- a/teams-infra-app.yaml
+++ b/teams-infra-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: teams-infra
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/Piotr1215/infra-platform-arch
+    path: teams
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
This PR adds the infrastructure setup for Team2 using vCluster and Crossplane.